### PR TITLE
Escaping search keyword

### DIFF
--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -579,9 +579,10 @@ jQuery.fn.flexdatalist = function (options, value) {
      * Wrap found keyword with span.highlight.
      */
         $this._highlight = function (keyword, text) {
+            var keywordEscaped = keyword.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
             if (text) {
                 return text.replace(
-                    new RegExp(keyword, ($this._options('searchContain') ? "ig" : "i")),
+                    new RegExp(keywordEscaped, ($this._options('searchContain') ? "ig" : "i")),
                     '|:|$&|::|'
                 );
             }


### PR DESCRIPTION
For the search to work with special chars (i.e. parantheses) the keyword has to be escaped. That's what the additional keyword.replace() is for.