### PR TITLE
Fixed value duplication bug (#118) for multiple mode

### DIFF
--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -668,10 +668,12 @@ jQuery.fn.flexdatalist = function (_option, _value) {
              */
                 push: function (val, index) {
                     var current = _this.fvalue.get();
-                    val = _this.fvalue.toObj(val);
-                    current.push(val);
-                    val = _this.fvalue.toStr(current);
-                    _this.value = val;
+                    if (!current.includes(val)) {
+                        val = _this.fvalue.toObj(val);
+                        current.push(val);
+                        val = _this.fvalue.toStr(current);
+                        _this.value = val;
+                    }
                 },
             /**
              * Toggle value.


### PR DESCRIPTION
This fixes #118, by validating whether a value is already present on the current values list before adding it. It will prevent the following value to be possible:

    PHP,PHP,Swift

By blocking duplicates, the wrong value above would simply be:

    PHP,Swift