### PR TITLE
Fixed hidden input when removing items when set to multiple

### DIFF
--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -725,11 +725,10 @@ jQuery.fn.flexdatalist = function (_option, _value) {
                         values = _this.fvalue.toStr(values);
                         _this.value = values;
                         $li.remove();
-                        _this.fvalue.multiple.checkLimit();
 
                         // For allowDuplicateValues
                         _selectedValues.splice(index, 1);
-
+                        _this.fvalue.multiple.checkLimit();
                         return arg;
                     }
                 },


### PR DESCRIPTION
When limitOfValues is set to 1 and you have selected 2 items after you remove one the input is set to display:none because the array still has the value. So put the checkLimit to the end of the remove method and it works all fine.