### PR TITLE
Add no-results Event

### DIFF
--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -135,7 +135,7 @@ jQuery.fn.flexdatalist = function (_option, _value) {
         var $this = $(this),
             _this = this,
             _searchTimeout = null,
-            _selectedValues = [], 
+            _selectedValues = [],
             fid = 'flex' + id,
             $alias = null,
             $multiple = null;
@@ -1395,6 +1395,7 @@ jQuery.fn.flexdatalist = function (_option, _value) {
                     .addClass('item no-results')
                     .append(text)
                     .appendTo($container)
+                    $this.trigger('no-results');
             },
         /**
          * Items iteration.


### PR DESCRIPTION
Currently, there isn't a no-results event to tap into, as the `shown:flexdatalist.results` does not fire when no results are found.

This change adds a no results that can be tapped into:

Example:
`$('input.flexdatalist').on('no-result', function(event, set, options)`