### PR TITLE
match integer value

### DIFF
--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -564,7 +564,7 @@ jQuery.fn.flexdatalist = function (_option, _value) {
                                 for (var idx = 0; idx < valueProp.length; idx++) {
                                     var prop = valueProp[idx],
                                     value = _this.isDefined(value, prop) ? value[prop] : value;
-                                    if (_this.isDefined(item, prop) && value === item[prop]) {
+                                    if (_this.isDefined(item, prop) && (value === item[prop] || parseInt(value) === item[prop])) {
                                         found.push(item);
                                     }
                                 }

--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -1442,7 +1442,7 @@ jQuery.fn.flexdatalist = function (_option, _value) {
                             // Other text properties
                             $item = $('<span>')
                                 .addClass('item item-' + visibleProperty)
-                                .html(propertyText==null?'':propertyText + ' ');
+                                .html(propertyText==`no ${visibleProperty}`?'':propertyText + ' ');
                         }
                     }
 

--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -1442,7 +1442,7 @@ jQuery.fn.flexdatalist = function (_option, _value) {
                             // Other text properties
                             $item = $('<span>')
                                 .addClass('item item-' + visibleProperty)
-                                .html(propertyText + ' ');
+                                .html(propertyText==null?'':propertyText + ' ');
                         }
                     }
 

--- a/jquery.flexdatalist.js
+++ b/jquery.flexdatalist.js
@@ -1442,7 +1442,7 @@ jQuery.fn.flexdatalist = function (_option, _value) {
                             // Other text properties
                             $item = $('<span>')
                                 .addClass('item item-' + visibleProperty)
-                                .html(propertyText==`no ${visibleProperty}`?'':propertyText + ' ');
+                                .html(propertyText==null?`no ${visibleProperty}`:propertyText + ' ');
                         }
                     }
 


### PR DESCRIPTION
So since it's a strict comparison (`===` and not `==`), when `value` is a stringified number,  it won't match with `item[prop]` if the prop is an integer. After some debugging, it appears that `value` seems **always** to be a string even if we pass an integer as value in `$.flexdatalist('add', 10)` for example. So that's why I'm doing this PR.
Parsing `value` may not be the best solution but it work fine for me.