### PR TITLE
Fix disabled check causing the input control to be made visible again

### DIFF
--- a/packages/core/src/flexdatalist.js
+++ b/packages/core/src/flexdatalist.js
@@ -2528,7 +2528,7 @@ class Flexdatalist {
             const ic = this._multipleEl.querySelector('li.input-container');
             this._multipleEl.classList.toggle('disabled', disabled);
             btns.forEach(b => { b.style.display = disabled ? 'none' : ''; });
-            if (ic) {
+            if (ic && ic.style.display !== "none") {
                 ic.style.display = disabled ? 'none' : '';
             }
         }

--- a/packages/core/src/flexdatalist.js
+++ b/packages/core/src/flexdatalist.js
@@ -2528,8 +2528,12 @@ class Flexdatalist {
             const ic = this._multipleEl.querySelector('li.input-container');
             this._multipleEl.classList.toggle('disabled', disabled);
             btns.forEach(b => { b.style.display = disabled ? 'none' : ''; });
-            if (ic && ic.style.display !== "none") {
-                ic.style.display = disabled ? 'none' : '';
+            if (ic) {
+                if (disabled) {
+                    ic.style.display = 'none';
+                } else {
+                    this._multipleHandleLimit();
+                }
             }
         }
 
@@ -2561,7 +2565,11 @@ class Flexdatalist {
                 b.style.display = ro ? 'none' : '';
             });
             if (ic) {
-                ic.style.display = ro ? 'none' : '';
+                if (ro) {
+                    ic.style.display = 'none';
+                } else {
+                    this._multipleHandleLimit();
+                }
             }
         }
 


### PR DESCRIPTION
Fix disabled check causing the input control to be made visible again, when another check decided it should not be.

This happens if for instance an initial value is set on the input and `limitOfValues=1`. The input control should not be visible because 1 option is already selected. But, the disabled check overrides this based only on the disabled property.